### PR TITLE
Change expected score dynamically and display win scene when game is won

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -427,11 +427,10 @@ public class GameManager : MonoBehaviour
             int Score = GameObject.FindGameObjectsWithTag("NORMAL_BALL").Length
                      + GameObject.FindGameObjectsWithTag("SAFE_BALL").Length;
 
-            Debug.Log(statusText);
             if (Score * 10 >= expectedScore) {
                 GameOverWin.gameObject.SetActive(true);
                 scoreLose = GameObject.Find("ScoreWin").GetComponent<Text>();
-                scoreLose.text = "SCORE: " + Score * 10; 
+                scoreLose.text = "SCORE: " + Score * 10;
             } else {
                 GameOverLose.gameObject.SetActive(true);
                 scoreLose = GameObject.Find("ScoreLose").GetComponent<Text>();

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -325,7 +325,7 @@ public class GameManager : MonoBehaviour
         maxY = 5;
         minDistance = 0.4f;
         sec = 30;
-        expectedScore = level * 10;
+        expectedScore = level > 100 ? (level % 100) * 10 : level * 10;
         Virus = GameObject.Find("Virus");
         Virus.transform.localScale = new Vector3(0.8f, 0.8f, 0.8f);
         timeText = GameObject.Find("TimeText").GetComponent<Text>();

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -45,7 +45,7 @@ public class GameManager : MonoBehaviour
     private int infectionLimit = 100;
     private const int INFECTION_RATIO_LIMIT = 100;
     private int frameCount = 0;
-    private int expectedScore = 20;
+    private int expectedScore;
     private GameObject tutorialCircle;
     private LineRenderer lineRenderer;
     private Vector3 lineStart = new Vector3(-2, 0, 0);
@@ -325,6 +325,7 @@ public class GameManager : MonoBehaviour
         maxY = 5;
         minDistance = 0.4f;
         sec = 30;
+        expectedScore = level * 10;
         Virus = GameObject.Find("Virus");
         Virus.transform.localScale = new Vector3(0.8f, 0.8f, 0.8f);
         timeText = GameObject.Find("TimeText").GetComponent<Text>();
@@ -428,11 +429,13 @@ public class GameManager : MonoBehaviour
 
             Debug.Log(statusText);
             if (Score * 10 >= expectedScore) {
-                statusText.text = "Congrats!\n You survived! Score: "
-                        + Score * 10 + "\nExpected: " + expectedScore;
+                GameOverWin.gameObject.SetActive(true);
+                scoreLose = GameObject.Find("ScoreWin").GetComponent<Text>();
+                scoreLose.text = "SCORE: " + Score * 10; 
             } else {
-                statusText.text = "Level failed! \n Your Score: "
-                        + Score * 10 + "\nExpected: " + expectedScore;
+                GameOverLose.gameObject.SetActive(true);
+                scoreLose = GameObject.Find("ScoreLose").GetComponent<Text>();
+                scoreLose.text = "SCORE: " + Score * 10;
             }
             statusText.enabled = true;
         }


### PR DESCRIPTION
## Changes
- The game was still printing text on the screen when game was won instead of transitioning to the `GameOverWin` scene
- The expected score is now changed dynamically on each level and is equal to `level number * 10`

## Note
The operation to compute the expected score assumes that for `Normal Levels` the level number is in the form `101 for level 1`, `102 for level 2`, etc...